### PR TITLE
Error responses fail job and provide a bit more output

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8737,14 +8737,20 @@ const core = __nccwpck_require__(186);
 
 async function run() {
 	const SERVICEID = core.getInput('service-id') || process.env.SERVICEID;
-  const APIKEY = core.getInput('api-key') || process.env.APIKEY;
-  
+	const APIKEY = core.getInput('api-key') || process.env.APIKEY;
+
 	const response = await fetch('https://api.render.com/v1/services/' + SERVICEID + '/deploys', {
 		method: 'POST',
 		headers: { 'Authorization': `Bearer ${APIKEY}`}
-		})
+	})
 
-	core.info(`Response received: ${response.status}`)
+	response.json().then(data => {
+		if (response.ok) {
+			core.info(`Deploy ${data.status} - Commit: ${data.commit.message}`)
+		} else {
+			core.setFailed(`Deploy error: ${data.message} (status code ${response.status})`)
+		}
+	});
 }
 
 run().catch(e => core.setFailed(e.message));

--- a/src/action.js
+++ b/src/action.js
@@ -3,14 +3,20 @@ const core = require('@actions/core');
 
 async function run() {
 	const SERVICEID = core.getInput('service-id') || process.env.SERVICEID;
-  const APIKEY = core.getInput('api-key') || process.env.APIKEY;
-  
+	const APIKEY = core.getInput('api-key') || process.env.APIKEY;
+
 	const response = await fetch('https://api.render.com/v1/services/' + SERVICEID + '/deploys', {
 		method: 'POST',
 		headers: { 'Authorization': `Bearer ${APIKEY}`}
-		})
+	})
 
-	core.info(`Response received: ${response.status}`)
+	response.json().then(data => {
+		if (response.ok) {
+			core.info(`Deploy ${data.status} - Commit: ${data.commit.message}`)
+		} else {
+			core.setFailed(`Deploy error: ${data.message} (status code ${response.status})`)
+		}
+	});
 }
 
 run().catch(e => core.setFailed(e.message));


### PR DESCRIPTION
When error responses are received from the Render API it doesn't fail the job. I noticed this when encountering a 401 error upon first getting this setup. So this uses `Response.ok` to check if the response is successful, otherwise fails the job.

Also, I have been wanting a bit more output showing what Render responds with when triggering a deploy. Not 100% sure what's best for the output here, but the this should be a bit more useful.

e.g

```
Run dylanfm/render-deploy-action@status-fails
Deploy build_in_progress - Commit: Revert "Reference with sha"

This reverts commit 56d02be7aece6e5d050c3240abeb0be0e41e79ea.
```