### PR TITLE
Amigo can you update from node16 to node20

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,11 +4,11 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Update 'VARIANT' to pick a Node version: 20, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local arm64/Apple Silicon.
 		"args": {
-			"VARIANT": "16-bullseye"
+			"VARIANT": "20-bullseye"
 		}
 	},
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
Working on [Amigo can you update from node16 to node20](https://github.com/johnbeynon/render-deploy-action/issues/6)
‎
Updating the Node.js version from 16 to 20 in the devcontainer configuration.